### PR TITLE
Add loan portfolio visualization example

### DIFF
--- a/CODE/loan_portfolio_visualizer.py
+++ b/CODE/loan_portfolio_visualizer.py
@@ -1,0 +1,48 @@
+import argparse
+import csv
+import numpy as np
+import open3d as o3d
+
+
+def load_loans(csv_path):
+    """Load loan data from a CSV file."""
+    loans = []
+    with open(csv_path, newline="") as csvfile:
+        reader = csv.DictReader(csvfile)
+        for row in reader:
+            loans.append(row)
+    return loans
+
+
+def loans_to_point_cloud(loans):
+    """Convert loan records to an Open3D point cloud."""
+    points = []
+    colors = []
+    for row in loans:
+        balance = float(row["loanbalance"])
+        rate = float(row["loanrate"])
+        term_or_age = float(row["loantermOrAgeInMonths"])
+        flag = row["loanaddedOrRemovedFlag"].strip().lower()
+        added = flag in ("added", "new", "1", "true", "yes")
+
+        points.append([term_or_age, balance, rate])
+        colors.append([0.0, 1.0, 0.0] if added else [1.0, 0.0, 0.0])
+
+    cloud = o3d.geometry.PointCloud()
+    cloud.points = o3d.utility.Vector3dVector(np.array(points, dtype=float))
+    cloud.colors = o3d.utility.Vector3dVector(np.array(colors, dtype=float))
+    return cloud
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Visualize loan portfolio data")
+    parser.add_argument("csv_file", help="CSV file containing loan data")
+    args = parser.parse_args()
+
+    loans = load_loans(args.csv_file)
+    cloud = loans_to_point_cloud(loans)
+    o3d.visualization.draw_geometries([cloud])
+
+
+if __name__ == "__main__":
+    main()

--- a/DATA/loan_data_example.csv
+++ b/DATA/loan_data_example.csv
@@ -1,0 +1,7 @@
+loanbalance,loanrate,loanaddedOrRemovedFlag,loantermOrAgeInMonths
+10000,5.5,added,60
+8000,4.2,added,48
+5000,6.0,removed,36
+15000,3.8,added,72
+4000,5.0,removed,24
+

--- a/README.md
+++ b/README.md
@@ -22,6 +22,26 @@ Documentation of the various scripts can be found on the related articles: [Medi
 * [LasPy](https://laspy.readthedocs.io/en/latest/) - A Python library for reading, modifying and writing LAS files. 
 * [Matplotlib](https://matplotlib.org/) - A library for creating static, animated, and interactive visualizations in Python.
 
+## Loan Portfolio Visualization
+
+The repository now includes a small example showing how point-cloud tools can visualize
+loan portfolio metrics. The `loan_portfolio_visualizer.py` script reads a CSV file
+containing `loanbalance`, `loanrate`, `loanaddedOrRemovedFlag`, and
+`loantermOrAgeInMonths` columns. Each loan is mapped to a 3D point where:
+
+* **X** = loan term or age in months
+* **Y** = balance
+* **Z** = interest rate
+
+Points are colored green for newly added loans and red for loans that have been
+removed. To try it out, run:
+
+```bash
+python CODE/loan_portfolio_visualizer.py DATA/loan_data_example.csv
+```
+
+This will open an interactive Open3D window displaying the loan portfolio.
+
 ## Acknowledgments
 
 These tools are developed after my PhD, in order to try and support developers & researchers in their point cloud processing endavour, from scratch.


### PR DESCRIPTION
## Summary
- add a new `loan_portfolio_visualizer.py` script that loads loan data and displays it as a colored 3D point cloud
- include example CSV data for loans
- document the new visualization capability in `README.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e5bc97bf88321bb3114206136edc3