### PR TITLE
Update open3d installation docs

### DIFF
--- a/CODE/loan_portfolio_visualizer.py
+++ b/CODE/loan_portfolio_visualizer.py
@@ -3,6 +3,11 @@ import csv
 import numpy as np
 import open3d as o3d
 
+"""Visualize loan portfolio data in 3D using Open3D.
+
+This script requires the :mod:`open3d` package to be installed.
+"""
+
 
 def load_loans(csv_path):
     """Load loan data from a CSV file."""

--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ A computer with internet access, and (optionnally), a Gmail and GDrive account t
 
 ## Installing
 
-Nothing to install.
+Install the required visualization library before running the examples:
+
+```bash
+pip install open3d
+```
 
 ## Documentation
 


### PR DESCRIPTION
## Summary
- instruct installing `open3d` in README
- note that `loan_portfolio_visualizer.py` requires `open3d`

## Testing
- `pytest -q`
- `MACHINE_NAME=rover pytest -q`
- `MACHINE_NAME=UI pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e63d30dc48321ae813e9810e0b30f