### PR TITLE
Fix compatibility for Open3D versions without add_3d_label

### DIFF
--- a/CODE/loan_portfolio_visualizer.py
+++ b/CODE/loan_portfolio_visualizer.py
@@ -73,7 +73,7 @@ def _add_spheres_to_visualizer(
     """Add spheres and numerical labels to the visualizer."""
     for idx, sphere in enumerate(spheres):
         vis.add_geometry(sphere)
-        if idx < 99:
+        if idx < 99 and hasattr(vis, "add_3d_label"):
             vis.add_3d_label(sphere.get_center(), str(idx + 1))
 
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,12 @@ A computer with internet access, and (optionnally), a Gmail and GDrive account t
 Install the required visualization library before running the examples:
 
 ```bash
-pip install open3d
+pip install "open3d>=0.13"
 ```
+
+If you install an earlier version of Open3D, the numeric labels
+displayed above each sphere will be omitted because the
+`add_3d_label` method was introduced in later versions.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary
- skip label creation if Visualizer has no `add_3d_label`
- mention required Open3D version in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fb8e99308832188850aee66b69be6