### PR TITLE
Fix visualization freezing

### DIFF
--- a/CODE/loan_portfolio_visualizer.py
+++ b/CODE/loan_portfolio_visualizer.py
@@ -97,10 +97,17 @@ def main() -> None:
     try:
         last_mtime = os.path.getmtime(csv_path)
         prev_loans = loans
+        check_interval = 5.0
+        last_check = time.time()
+
         while True:
-            time.sleep(5)
             vis.poll_events()
             vis.update_renderer()
+            time.sleep(0.05)
+
+            if time.time() - last_check < check_interval:
+                continue
+            last_check = time.time()
 
             try:
                 mtime = os.path.getmtime(csv_path)


### PR DESCRIPTION
## Summary
- keep Open3D visualizer responsive by polling events frequently

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68702f87811c83219778b62bfc290070