### PR TITLE
Add sample data generation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ removed. To try it out, run:
 python CODE/loan_portfolio_visualizer.py DATA/loan_data_example.csv
 ```
 
-This will open an interactive Open3D window displaying the loan portfolio.
+When launched, the script asks whether you want to generate a fresh
+``loan_data_example.csv`` with 1,000 random records. Choose ``y`` to overwrite
+the file or ``n`` to use the existing data. This will open an interactive
+Open3D window displaying the loan portfolio.
 
 ## Acknowledgments
 


### PR DESCRIPTION
## Summary
- add a clustered data generator for loan examples
- prompt the user to create a new dataset when running the visualizer
- update README to describe the data generation prompt

## Testing
- `python -m py_compile CODE/loan_portfolio_visualizer.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68704d7f6d08832197ff820260466677