### PR TITLE
Handle older Open3D versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ pip install -r requirements.txt
 If you install an earlier version of Open3D than the one listed in
 ``requirements.txt``, the numeric labels displayed above each sphere
 will be omitted because the ``add_3d_label`` method was introduced in
-later versions.
+later versions. Similarly, axis titles rely on the
+``TriangleMesh.create_text_3d`` API added in more recent Open3D
+releases. When this function is unavailable, the script falls back to
+lighter 3D labels or omits the titles entirely.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary
- gracefully handle missing `TriangleMesh.create_text_3d`
- add helper to draw axis labels with either 3D text or 3D labels
- document fallback behaviour in README

## Testing
- `python -m py_compile CODE/loan_portfolio_visualizer.py`


------
https://chatgpt.com/codex/tasks/task_e_6871e9e46cc08321a8b6cbd29c58e0ed