### PR TITLE
Add face titles helper and update docs

### DIFF
--- a/CODE/loan_portfolio_visualizer.py
+++ b/CODE/loan_portfolio_visualizer.py
@@ -31,6 +31,31 @@ def _add_axis_labels(vis: o3d.visualization.Visualizer, grid_size: float) -> Non
         # No supported method for text rendering.
         pass
 
+
+def add_face_titles(
+    vis: o3d.visualization.Visualizer,
+    grid_size: float,
+    scale: float = 0.07,
+    color=(1.0, 1.0, 1.0),
+) -> None:
+    """Place one title on each positive-axis face of the grid."""
+
+    if not hasattr(o3d.geometry.TriangleMesh, "create_text_3d"):
+        return  # Old Open3D build – silently skip
+
+    eps = 0.03 * grid_size
+    half = 0.5 * grid_size
+
+    definitions = [
+        ("Term/Age", [half, -eps, 0.0]),
+        ("Balance", [-eps, half, 0.0]),
+        ("Rate", [-eps, -eps, half]),
+    ]
+
+    for text, pos in definitions:
+        mesh = _text_mesh(text, pos, scale=scale, color=color)
+        vis.add_geometry(mesh)
+
 def _text_mesh(
     text: str,
     position: Iterable[float],
@@ -281,7 +306,7 @@ def main() -> None:
     vis.add_geometry(grid_xz)
     vis.add_geometry(grid_yz)
     vis.add_geometry(axis)
-    _add_axis_labels(vis, grid_size)
+    add_face_titles(vis, grid_size)
 
     vis.poll_events()
     vis.update_renderer()
@@ -328,7 +353,7 @@ def main() -> None:
             vis.add_geometry(grid_xz)
             vis.add_geometry(grid_yz)
             vis.add_geometry(axis)
-            _add_axis_labels(vis, grid_size)
+            add_face_titles(vis, grid_size)
 
             vis.get_view_control().convert_from_pinhole_camera_parameters(camera)
     except KeyboardInterrupt:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A suite of scripts and easy-to-follow tutorial to process point cloud data with 
 ## Prerequisites
 
 A computer with internet access, and (optionnally), a Gmail and GDrive account to make it work out of the box.
-Python 3.8 or later.
+Python 3.11 or later.
 
 ## Installing
 
@@ -15,7 +15,7 @@ Install the required libraries before running the examples:
 pip install -r requirements.txt
 ```
 
-If you install an earlier version of Open3D than the one listed in
+If you install an earlier version of Open3D than ``0.19.0`` listed in
 ``requirements.txt``, the numeric labels displayed above each sphere
 will be omitted because the ``add_3d_label`` method was introduced in
 later versions. Similarly, axis titles rely on the

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-open3d>=0.13
+open3d==0.19.0
 numpy
 matplotlib


### PR DESCRIPTION
## Summary
- support labeling grid faces using `add_face_titles`
- mention Python 3.11 and Open3D 0.19.0 in README
- pin Open3D 0.19.0 in requirements

## Testing
- `python -m compileall CODE`

------
https://chatgpt.com/codex/tasks/task_e_68727af46e6083219d94960cfd997a0d