### PR TITLE
Add dark backdrop planes for grid

### DIFF
--- a/CODE/loan_portfolio_visualizer.py
+++ b/CODE/loan_portfolio_visualizer.py
@@ -275,6 +275,24 @@ def _create_grid(
     return line_set
 
 
+def _create_background_wall(
+    width: float,
+    height: float,
+    depth: float,
+    offset: List[float],
+    axis: str = "xy",
+    color=(0.1, 0.1, 0.1),
+) -> o3d.geometry.TriangleMesh:
+    """Return a thin colored plane placed behind a grid."""
+
+    mesh = o3d.geometry.TriangleMesh.create_box(
+        width=width, height=height, depth=depth
+    )
+    mesh.paint_uniform_color(list(color))
+    mesh.translate(offset)
+    return mesh
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Visualize loan portfolio data and monitor for updates"
@@ -301,10 +319,34 @@ def main() -> None:
     grid_xy = _create_grid(size=grid_size, divisions=10, plane="xy", positive_only=True)
     grid_xz = _create_grid(size=grid_size, divisions=10, plane="xz", positive_only=True)
     grid_yz = _create_grid(size=grid_size, divisions=10, plane="yz", positive_only=True)
+    wall_xy = _create_background_wall(
+        grid_size,
+        grid_size,
+        0.001,
+        [0.0, 0.0, -0.001],
+        "xy",
+    )
+    wall_xz = _create_background_wall(
+        grid_size,
+        0.001,
+        grid_size,
+        [0.0, -0.001, 0.0],
+        "xz",
+    )
+    wall_yz = _create_background_wall(
+        0.001,
+        grid_size,
+        grid_size,
+        [-0.001, 0.0, 0.0],
+        "yz",
+    )
     axis = o3d.geometry.TriangleMesh.create_coordinate_frame(size=0.2)
     vis.add_geometry(grid_xy)
     vis.add_geometry(grid_xz)
     vis.add_geometry(grid_yz)
+    vis.add_geometry(wall_xy)
+    vis.add_geometry(wall_xz)
+    vis.add_geometry(wall_yz)
     vis.add_geometry(axis)
     add_face_titles(vis, grid_size)
 
@@ -348,10 +390,34 @@ def main() -> None:
             grid_xy = _create_grid(size=grid_size, divisions=10, plane="xy", positive_only=True)
             grid_xz = _create_grid(size=grid_size, divisions=10, plane="xz", positive_only=True)
             grid_yz = _create_grid(size=grid_size, divisions=10, plane="yz", positive_only=True)
+            wall_xy = _create_background_wall(
+                grid_size,
+                grid_size,
+                0.001,
+                [0.0, 0.0, -0.001],
+                "xy",
+            )
+            wall_xz = _create_background_wall(
+                grid_size,
+                0.001,
+                grid_size,
+                [0.0, -0.001, 0.0],
+                "xz",
+            )
+            wall_yz = _create_background_wall(
+                0.001,
+                grid_size,
+                grid_size,
+                [-0.001, 0.0, 0.0],
+                "yz",
+            )
             axis = o3d.geometry.TriangleMesh.create_coordinate_frame(size=0.2)
             vis.add_geometry(grid_xy)
             vis.add_geometry(grid_xz)
             vis.add_geometry(grid_yz)
+            vis.add_geometry(wall_xy)
+            vis.add_geometry(wall_xz)
+            vis.add_geometry(wall_yz)
             vis.add_geometry(axis)
             add_face_titles(vis, grid_size)
 


### PR DESCRIPTION
## Summary
- create `_create_background_wall` helper for grid walls
- show dark wall planes behind each grid face

## Testing
- `pytest -q`
- `python -m py_compile CODE/loan_portfolio_visualizer.py`


------