### PR TITLE
Fix Open3D normal warnings

### DIFF
--- a/CODE/loan_portfolio_visualizer.py
+++ b/CODE/loan_portfolio_visualizer.py
@@ -82,6 +82,7 @@ def _text_mesh(
         mesh.paint_uniform_color(list(color))
     mesh.scale(scale, center=(0.0, 0.0, 0.0))
     mesh.translate(list(position))
+    mesh.compute_vertex_normals()
     return mesh
 
 # Default number of records used when generating sample data.
@@ -213,6 +214,7 @@ def loans_to_spheres(
         mesh = o3d.geometry.TriangleMesh.create_sphere(radius=radius)
         mesh.translate(point)
         mesh.paint_uniform_color(colors[idx])
+        mesh.compute_vertex_normals()
         spheres.append(mesh)
 
     return spheres
@@ -305,6 +307,7 @@ def _create_background_wall(
     )
     mesh.paint_uniform_color(list(color))
     mesh.translate(offset)
+    mesh.compute_vertex_normals()
     return mesh
 
 


### PR DESCRIPTION
## Summary
- compute vertex normals for spheres, background walls and text to avoid shader warnings

## Testing
- `python -m py_compile CODE/*.py`
- `pip install open3d==0.19.0 > /tmp/pip.log && tail -n 20 /tmp/pip.log`
- `python CODE/loan_portfolio_visualizer.py DATA/loan_data_example.csv > /tmp/script.log && tail -n 20 /tmp/script.log` *(fails: OSError: libGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_688052b982f88321afc5bbe38eafd4bd